### PR TITLE
Promise callback doesn't receive error anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ tmplconv.render('asset/app-tmpl', 'demo/demo-app', {
     'name': 'my-awesome-app',
     'description': "This is an example for the app templates."
   }
-}).then((err) => {
+}).then((result) => {
   /* ... */
 })
 


### PR DESCRIPTION
The callback given to `.then` does not receive an error object, but the result of the operation now.